### PR TITLE
Make numpy and scipy stubs optional

### DIFF
--- a/scipy/__init__.py
+++ b/scipy/__init__.py
@@ -1,13 +1,26 @@
-"""Minimal stub of the :mod:`scipy` package.
+"""Provide :mod:`scipy` if the real library is missing.
 
-This lightweight implementation only exposes the parts of SciPy required by
-this repository.  Currently it provides the :mod:`scipy.special` submodule with
-basic implementations of :func:`digamma` and :func:`polygamma`.  It exists so
-that code written for SciPy can run in environments where the real library is
-unavailable.
+When imported, this module first checks whether a genuine SciPy installation is
+available.  If so, it loads that package and re-exports all of its symbols.
+Otherwise a very small subset of functionality implemented in ``scipy.special``
+is provided so that the rest of the codebase can run in restricted
+environments.
 """
 
-from . import special
+from __future__ import annotations
 
-__all__ = ["special"]
+import importlib.machinery
+import importlib.util
+import sys
+
+_spec = importlib.machinery.PathFinder().find_spec(__name__, sys.path[1:])
+if _spec is not None:
+    _module = importlib.util.module_from_spec(_spec)
+    sys.modules[__name__] = _module
+    _spec.loader.exec_module(_module)
+    globals().update(_module.__dict__)
+else:
+    from . import special
+
+    __all__ = ["special"]
 


### PR DESCRIPTION
## Summary
- detect installed numpy and re-export it instead of using the local stub
- detect installed scipy and re-export it instead of using the local stub

## Testing
- `python tests/test_analytic.py && python tests/test_unbiased.py`