### PR TITLE
Add fixed sampling utilities

### DIFF
--- a/fixed_sampling.py
+++ b/fixed_sampling.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+"""Utility helpers for fixed-sample log-likelihood estimation.
+
+This module collects different ways of estimating the log-probability
+from a fixed number of simulator samples.  Each method expects the
+number of matching simulator outputs (``matches``) and the total number
+of samples ``M``.  The methods are exposed via :data:`FIXED_METHODS`.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Callable, Dict
+
+
+def _naive(matches: int, M: int) -> float:
+    """Return ``log(matches / M)`` or ``-inf`` if ``matches`` is zero."""
+    if M <= 0:
+        raise ValueError("M must be positive")
+    return math.log(matches / M) if matches else float("-inf")
+
+
+def _laplace(matches: int, M: int) -> float:
+    """Return Laplace-smoothed log probability ``log((m + 1)/(M + 1))``."""
+    if M < 0:
+        raise ValueError("M must be non-negative")
+    return math.log((matches + 1) / (M + 1))
+
+
+def _jeffreys(matches: int, M: int) -> float:
+    """Jeffreys prior ``log((m + 0.5)/(M + 1))``."""
+    if M < 0:
+        raise ValueError("M must be non-negative")
+    return math.log((matches + 0.5) / (M + 1))
+
+
+def _clipped(matches: int, M: int, eps: float = 1e-12) -> float:
+    """Naive estimate with clipping to avoid log(0)."""
+    if M <= 0:
+        raise ValueError("M must be positive")
+    p = matches / M
+    if p <= 0.0:
+        p = eps
+    elif p >= 1.0:
+        p = 1.0 - eps
+    return math.log(p)
+
+
+# Mapping of method name to log-probability estimator
+FIXED_METHODS: Dict[str, Callable[[int, int], float]] = {
+    "naive": _naive,
+    "laplace": _laplace,
+    "jeffreys": _jeffreys,
+    "clipped": _clipped,
+}
+
+
+def fixed_loglikelihood(
+    stimuli,
+    responses,
+    model: Callable[[object, object], object],
+    theta: object,
+    M: int,
+    method: str = "naive",
+) -> tuple[float, int]:
+    """Estimate log-likelihood with ``M`` samples per trial.
+
+    Parameters
+    ----------
+    stimuli, responses
+        Sequences describing the observations.
+    model
+        Simulator returning a response for ``(theta, stimulus)``.
+    theta
+        Parameters passed to ``model``.
+    M : int
+        Number of simulator samples per trial.
+    method : str, optional
+        Name of the log-probability estimator from :data:`FIXED_METHODS`.
+
+    Returns
+    -------
+    log_lik : float
+        Estimated log-likelihood.
+    total_samples : int
+        Total number of simulator samples used.
+    """
+    if method not in FIXED_METHODS:
+        raise KeyError(f"Unknown method '{method}'")
+    log_fn = FIXED_METHODS[method]
+
+    log_lik = 0.0
+    for s, r_obs in zip(stimuli, responses):
+        matches = 0
+        for _ in range(M):
+            if model(theta, s) == r_obs:
+                matches += 1
+        log_lik += log_fn(matches, M)
+    total_samples = M * len(stimuli)
+    return log_lik, total_samples

--- a/plot_sampling_efficiency.py
+++ b/plot_sampling_efficiency.py
@@ -8,6 +8,7 @@ import statistics
 from ibs import ibs_loglikelihood
 from setup_matplotlib import setup_matplotlib
 from sampling_colors import get_color
+from fixed_sampling import fixed_loglikelihood
 
 try:
     from matplotlib import pyplot as plt
@@ -23,19 +24,6 @@ def bernoulli_model(rng):
 
     return model
 
-
-def fixed_loglikelihood(stimuli, responses, model, theta, M):
-    """Estimate log-likelihood with a fixed number of samples per trial."""
-    log_lik = 0.0
-    for s, r_obs in zip(stimuli, responses):
-        matches = 0
-        for _ in range(M):
-            if model(theta, s) == r_obs:
-                matches += 1
-        prob = matches / M if matches else 1e-12
-        log_lik += math.log(prob)
-    total_samples = M * len(responses)
-    return log_lik, total_samples
 
 
 def run_experiment(p=0.3, n_trials=20, repetitions=100, seed=123):
@@ -59,8 +47,9 @@ def run_experiment(p=0.3, n_trials=20, repetitions=100, seed=123):
         samples = []
         for rep in range(repetitions):
             rng_run = random.Random(seed + rep)
-            ll, n = fixed_loglikelihood(stimuli, responses,
-                                        bernoulli_model(rng_run), p, M)
+            ll, n = fixed_loglikelihood(
+                stimuli, responses, bernoulli_model(rng_run), p, M, method="clipped"
+            )
             estimates.append(ll)
             samples.append(n)
         mean_ll = statistics.mean(estimates)

--- a/tests/test_fixed.py
+++ b/tests/test_fixed.py
@@ -1,0 +1,24 @@
+import math
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from fixed_sampling import FIXED_METHODS
+
+
+def test_fixed_methods_basic():
+    m = 5
+    M = 10
+    expected = {
+        "naive": math.log(0.5),
+        "laplace": math.log((m + 1) / (M + 1)),
+        "jeffreys": math.log((m + 0.5) / (M + 1)),
+        "clipped": math.log(0.5),
+    }
+    for name, func in FIXED_METHODS.items():
+        val = func(m, M)
+        assert abs(val - expected[name]) < 1e-12
+
+
+def test_fixed_clipped_zero():
+    val = FIXED_METHODS["clipped"](0, 10)
+    assert math.isfinite(val)


### PR DESCRIPTION
## Summary
- support several fixed-sample log probability estimators
- use new helper in `plot_sampling_efficiency`
- test the dictionary of fixed sampling methods

## Testing
- `python tests/test_fixed.py`
- `python tests/test_analytic.py`
- `python tests/test_unbiased.py`
