### PR TITLE
Add fixed sampling analytic moments

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,4 +16,7 @@ all plots.
 The file `fixed_sampling.py` provides several simple log-probability estimators
 for binary observations based on a fixed number of samples. Methods such as the
 naive empirical mean, a ``+1`` adjustment, Laplace smoothing, and Jeffreys
-smoothing are available via the ``FIXED_SAMPLING_METHODS`` dictionary.
+smoothing are available via the ``FIXED_SAMPLING_METHODS`` dictionary.  In
+addition, ``fixed_analytical_mean`` and ``fixed_analytical_variance`` can be
+used to compute the expected value and variance of these estimators given the
+true success probability and number of samples ``M``.

--- a/sampling_colors.py
+++ b/sampling_colors.py
@@ -4,12 +4,10 @@ from __future__ import annotations
 
 _COLOR_MAP = {
     "ibs": "tab:blue",
-    "fixed_1": "tab:orange",
-    "fixed_2": "tab:green",
-    "fixed_3": "tab:red",
-    "fixed_5": "tab:purple",
-    "fixed_8": "tab:brown",
-    "fixed_10": "tab:pink",
+    "naive": "tab:orange",
+    "fixed": "tab:green",
+    "laplace": "tab:red",
+    "jeffreys": "tab:purple",
 }
 
 

--- a/tests/test_analytic.py
+++ b/tests/test_analytic.py
@@ -2,6 +2,11 @@ import os, sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 import math
 from ibs import ibs_analytical_mean, ibs_analytical_variance
+from fixed_sampling import (
+    fixed_analytical_mean,
+    fixed_analytical_variance,
+    FIXED_SAMPLING_PARAMS,
+)
 
 
 def test_analytic_mean_variance_single():
@@ -12,3 +17,27 @@ def test_analytic_mean_variance_single():
     assert abs(mean - math.log(p)) < 1e-12
     # variance should be less than 1 and positive
     assert 0.0 <= var < 1.0
+
+
+def _expected_fixed_moments(p, M, alpha, beta):
+    mean = 0.0
+    for k in range(M + 1):
+        prob = math.comb(M, k) * (p ** k) * ((1 - p) ** (M - k))
+        mean += prob * math.log((k + alpha) / (M + beta))
+    var = 0.0
+    for k in range(M + 1):
+        prob = math.comb(M, k) * (p ** k) * ((1 - p) ** (M - k))
+        val = math.log((k + alpha) / (M + beta))
+        var += prob * (val - mean) ** 2
+    return mean, var
+
+
+def test_fixed_analytic_methods():
+    p = 0.25
+    M = 4
+    for method, (alpha, beta) in FIXED_SAMPLING_PARAMS.items():
+        mean = fixed_analytical_mean([p], M, method)
+        var = fixed_analytical_variance([p], M, method)
+        exp_mean, exp_var = _expected_fixed_moments(p, M, alpha, beta)
+        assert abs(mean - exp_mean) < 1e-12
+        assert abs(var - exp_var) < 1e-12


### PR DESCRIPTION
## Summary
- add `fixed_analytical_mean` and `fixed_analytical_variance`
- store prior parameters for each fixed sampling method
- map colours to sampling methods
- document analytical helpers in the README
- test fixed sampling analytical formulas

## Testing
- `python tests/test_analytic.py`
- `python tests/test_unbiased.py`
